### PR TITLE
Add support for mlx arrays

### DIFF
--- a/wadler_lindig/_definitions.py
+++ b/wadler_lindig/_definitions.py
@@ -234,7 +234,12 @@ def _pformat_dict(obj: dict, **kwargs) -> AbstractDoc:
 def _array_kind(x) -> None | str:
     # For pragmatic reasons we ship with support for NumPy + PyTorch + JAX out of the
     # box.
-    for module, array in [("numpy", "ndarray"), ("torch", "Tensor"), ("jax", "Array")]:
+    for module, array in [
+        ("numpy", "ndarray"),
+        ("torch", "Tensor"),
+        ("jax", "Array"),
+        ("mlx.core", "array"),
+    ]:
         if module in sys.modules and isinstance(x, getattr(sys.modules[module], array)):
             return module
     return None


### PR DESCRIPTION
I didn't add any tests since it seems there are no tests for pytorch and jax either. 

I tested it locally though with the following snippet:

```
import mlx.core as mx
import wadler_lindig as wl

wl.pprint(mx.zeros(shape=(25, 24, 26), dtype=mx.uint16))
# u16[25,24,26](mlx.core)
```

This PR should fix https://github.com/patrick-kidger/jaxtyping/issues/286#issuecomment-2671757280