### PR TITLE
feat: make `pformat_doc` public

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,10 @@ The main two functions are [`wadler_lindig.pprint`][] and [`wadler_lindig.pforma
 
 ::: wadler_lindig.pformat
 
+The lower-level function [`wadler_lindig.pformat_doc`][] is used to format a Wadler–Lindig document. This is the function that is called by `pprint` and `pformat`.
+
+::: wadler_lindig.pformat_doc
+
 ## Pretty diffs
 
 As a utility we offer [`wadler_lindig.pdiff`][] as a quick way to diff two strings. This is a thin wrapper around the Python built-in library `difflib`.

--- a/wadler_lindig/__init__.py
+++ b/wadler_lindig/__init__.py
@@ -11,6 +11,7 @@ from ._definitions import (
     pdoc as pdoc,
     pformat as pformat,
     pprint as pprint,
+    pformat_doc as pformat_doc,
 )
 from ._wadler_lindig import (
     AbstractDoc as AbstractDoc,


### PR DESCRIPTION
If you have a `wl.AbstractDoc` object and want to turn it into a string you need this function to be public.
Alternatively, maybe we could add a method `to_string()` to `wl.AbstractDoc` instead of making this function public?